### PR TITLE
get script dir

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export GIT_ROOT=$(cd $(dirname $0); pwd)
+export GIT_ROOT=$(cd $(dirname $0)/.. ; pwd)
 sudo docker run -it --rm --net=host --runtime nvidia -e DISPLAY=$DISPLAY \
 	-v ${GIT_ROOT}/yolox-docker/YOLOX_outputs:/root/YOLOX/YOLOX_outputs \
   -v ${GIT_ROOT}/yolox-docker:/root/YOLOX/yolox-docker \


### PR DESCRIPTION
# why
- Dockerのhost環境のディレクトリ位置が固定のスクリプトになっていた。
# what
- Dockerのhost環境のディレクトリ位置に依存しない書き方に変えた。
- スクリプトのあるディレクトリの親ディレクトリを絶対pathとして利用する。
